### PR TITLE
refactor: allow optional git configuration

### DIFF
--- a/GitConfigurationProvider/ConfigurationBuilderExtension.cs
+++ b/GitConfigurationProvider/ConfigurationBuilderExtension.cs
@@ -1,20 +1,17 @@
 using System;
+using LibGit2Sharp;
 using Microsoft.Extensions.Configuration;
 
 namespace KageKirin.Extensions.Configuration.GitConfig;
 
 public static class GitConfigurationProviderExtension
 {
-    public static IConfigurationBuilder AddGitConfig(
-        this IConfigurationBuilder builder
-    ) => AddGitConfig(builder, path: Environment.CurrentDirectory);
+    public static IConfigurationBuilder AddGitConfig(this IConfigurationBuilder builder, bool optional = true) =>
+        AddGitConfig(builder, path: Environment.CurrentDirectory, optional: optional);
 
-    public static IConfigurationBuilder AddGitConfig(
-        this IConfigurationBuilder builder,
-        string path
-    )
+    public static IConfigurationBuilder AddGitConfig(this IConfigurationBuilder builder, string path, bool optional = true)
     {
-        builder.Add(new GitConfigurationSource(path: path));
+        builder.Add(new GitConfigurationSource(path: path, optional: optional));
         return builder;
     }
 }

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -21,7 +21,8 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
 
     public override void Load()
     {
-        Debug.Assert(configuration != null);
+        if (!optional)
+            Debug.Assert(configuration != null);
 
         foreach (var entry in configuration)
         {

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -10,12 +10,13 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
     readonly LibGit2Sharp.Configuration? configuration;
     readonly bool optional = true;
 
-    public GitConfigurationProvider()
-        : this(Environment.CurrentDirectory) { }
+    public GitConfigurationProvider(bool optional = true)
+        : this(path: Environment.CurrentDirectory, optional: optional) { }
 
-    public GitConfigurationProvider(string path)
+    public GitConfigurationProvider(string path, bool optional = true)
     {
-        configuration = LibGit2Sharp.Configuration.BuildFrom(Repository.Discover(path), null, null, null);
+        this.configuration = LibGit2Sharp.Configuration.BuildFrom(Repository.Discover(path), null, null, null);
+        this.optional = optional;
     }
 
     public override void Load()

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -8,6 +8,7 @@ namespace KageKirin.Extensions.Configuration.GitConfig;
 public class GitConfigurationProvider : ConfigurationProvider, IDisposable
 {
     readonly LibGit2Sharp.Configuration? configuration;
+    readonly bool optional = true;
 
     public GitConfigurationProvider()
         : this(Environment.CurrentDirectory) { }

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -24,10 +24,15 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
         if (!optional)
             Debug.Assert(configuration != null);
 
-        foreach (var entry in configuration)
+        if (configuration != null)
         {
-            Console.WriteLine($"[gitconfig] reading [{entry.Level}] {entry.Key}: {entry.Value}");
-            Data[entry.Key.Replace(".", ":")] = entry.Value;
+            //configuration.ConfigurationEntry<T> Get<T>(string[] keyParts) for direct access? ms_configString.Split(':') to get key parts
+
+            foreach (var entry in configuration)
+            {
+                Console.WriteLine($"[gitconfig] reading [{entry.Level}] {entry.Key}: {entry.Value}");
+                Data[entry.Key.Replace(".", ":")] = entry.Value;
+            }
         }
     }
 

--- a/GitConfigurationProvider/GitConfigurationSource.cs
+++ b/GitConfigurationProvider/GitConfigurationSource.cs
@@ -7,14 +7,14 @@ public class GitConfigurationSource : IConfigurationSource
 {
     readonly Func<GitConfigurationProvider> buildAction;
 
-    public GitConfigurationSource()
+    public GitConfigurationSource(bool optional = true)
     {
-        buildAction = () => new GitConfigurationProvider();
+        buildAction = () => new GitConfigurationProvider(optional: optional);
     }
 
-    public GitConfigurationSource(string path)
+    public GitConfigurationSource(string path, bool optional = true)
     {
-        buildAction = () => new GitConfigurationProvider(path: path);
+        buildAction = () => new GitConfigurationProvider(path: path, optional: optional);
     }
 
     public IConfigurationProvider Build(IConfigurationBuilder builder)


### PR DESCRIPTION
- **feat: add private field 'optional' to GitConfigurationProvider**
  

- **refactor: set GitConfigurationProvider.optional from ctor**
  

- **refactor: change hard failure condition in GitConfigurationProvider.Load()**
  explainer: hard failure only occurs if .optional is false and .configuration is null
             i.e. the error cannot be ignored
  

- **refactor: avoid a potential null pointer access in GitConfigurationProvider.Load()**
  reason: load configuration values only if .configuration exists
  

- **refactor: forward 'optional' flag to GitConfigurationProvider.ctor() from GitConfigurationSource**
  

- **refactor: forward 'optional' flag to GitConfigurationSource.ctor() from IConfigurationBuilder.AddGitConfig() extension method**
  