### PR TITLE
feat: implement initial support for reloading the configuration on change

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
   </ItemGroup>
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,6 +8,7 @@
     <PackageVersion Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.FileProviders.Composite" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.Extensions.FileProviders.Physical" Version="9.0.4" />
     <PackageVersion Include="Microsoft.Extensions.Logging" Version="9.0.4" />
   </ItemGroup>
 

--- a/GitConfigurationProvider/ConfigurationBuilderExtension.cs
+++ b/GitConfigurationProvider/ConfigurationBuilderExtension.cs
@@ -27,7 +27,8 @@ public static class GitConfigurationProviderExtension
         string globalConfigurationPath,
         string xdgConfigurationPath,
         string systemConfigurationPath,
-        bool optional = true
+        bool optional = true,
+        bool reloadOnChange = false
     )
     {
         builder.Add(
@@ -36,7 +37,8 @@ public static class GitConfigurationProviderExtension
                 globalConfigurationPath: globalConfigurationPath,
                 xdgConfigurationPath: xdgConfigurationPath,
                 systemConfigurationPath: systemConfigurationPath,
-                optional: optional
+                optional: optional,
+                reloadOnChange: reloadOnChange
             )
         );
         return builder;

--- a/GitConfigurationProvider/ConfigurationBuilderExtension.cs
+++ b/GitConfigurationProvider/ConfigurationBuilderExtension.cs
@@ -9,9 +9,14 @@ public static class GitConfigurationProviderExtension
     public static IConfigurationBuilder AddGitConfig(this IConfigurationBuilder builder, bool optional = true) =>
         AddGitConfig(builder, path: Environment.CurrentDirectory, optional: optional);
 
-    public static IConfigurationBuilder AddGitConfig(this IConfigurationBuilder builder, string path, bool optional = true)
+    public static IConfigurationBuilder AddGitConfig(
+        this IConfigurationBuilder builder,
+        string path,
+        bool optional = true,
+        bool reloadOnChange = false
+    )
     {
-        builder.Add(new GitConfigurationSource(path: path, optional: optional));
+        builder.Add(new GitConfigurationSource(path: path, optional: optional, reloadOnChange: reloadOnChange));
         return builder;
     }
 

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -67,6 +67,12 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
         }
     }
 
+    private void Reload()
+    {
+        Data.Clear();
+        Load();
+    }
+
     public void Dispose()
     {
         configuration?.Dispose();

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -30,7 +30,8 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
         string globalConfigurationPath,
         string xdgConfigurationPath,
         string systemConfigurationPath,
-        bool optional = true
+        bool optional = true,
+        bool reloadOnChange = false
     )
         : this(
             configuration: LibGit2Sharp.Configuration.BuildFrom(

--- a/GitConfigurationProvider/GitConfigurationProvider.cs
+++ b/GitConfigurationProvider/GitConfigurationProvider.cs
@@ -19,8 +19,15 @@ public class GitConfigurationProvider : ConfigurationProvider, IDisposable
     public GitConfigurationProvider(bool optional = true)
         : this(path: Environment.CurrentDirectory, optional: optional) { }
 
-    public GitConfigurationProvider(string path, bool optional = true)
-        : this(LibGit2Sharp.Configuration.BuildFrom(Repository.Discover(path), null, null, null), optional: optional) { }
+    public GitConfigurationProvider(string path, bool optional = true, bool reloadOnChange = false)
+        : this(
+            repositoryConfigurationPath: Repository.Discover(path),
+            globalConfigurationPath: null,
+            xdgConfigurationPath: null,
+            systemConfigurationPath: null,
+            optional: optional,
+            reloadOnChange: reloadOnChange
+        ) { }
 
     public GitConfigurationProvider(Repository repository, bool optional = true)
         : this(configuration: repository.Config, optional: optional) { }

--- a/GitConfigurationProvider/GitConfigurationProvider.csproj
+++ b/GitConfigurationProvider/GitConfigurationProvider.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" />
     <PackageReference Include="LibGit2Sharp" />
   </ItemGroup>
 

--- a/GitConfigurationProvider/GitConfigurationProvider.csproj
+++ b/GitConfigurationProvider/GitConfigurationProvider.csproj
@@ -21,6 +21,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" />
     <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" />
+    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" />
     <PackageReference Include="LibGit2Sharp" />
   </ItemGroup>
 

--- a/GitConfigurationProvider/GitConfigurationSource.cs
+++ b/GitConfigurationProvider/GitConfigurationSource.cs
@@ -23,7 +23,8 @@ public class GitConfigurationSource : IConfigurationSource
         string globalConfigurationPath,
         string xdgConfigurationPath,
         string systemConfigurationPath,
-        bool optional = true
+        bool optional = true,
+        bool reloadOnChange = false
     )
     {
         buildAction = () =>
@@ -32,7 +33,8 @@ public class GitConfigurationSource : IConfigurationSource
                 globalConfigurationPath: globalConfigurationPath,
                 xdgConfigurationPath: xdgConfigurationPath,
                 systemConfigurationPath: systemConfigurationPath,
-                optional: optional
+                optional: optional,
+                reloadOnChange: reloadOnChange
             );
     }
 

--- a/GitConfigurationProvider/GitConfigurationSource.cs
+++ b/GitConfigurationProvider/GitConfigurationSource.cs
@@ -13,9 +13,9 @@ public class GitConfigurationSource : IConfigurationSource
         buildAction = () => new GitConfigurationProvider(optional: optional);
     }
 
-    public GitConfigurationSource(string path, bool optional = true)
+    public GitConfigurationSource(string path, bool optional = true, bool reloadOnChange = false)
     {
-        buildAction = () => new GitConfigurationProvider(path: path, optional: optional);
+        buildAction = () => new GitConfigurationProvider(path: path, optional: optional, reloadOnChange: reloadOnChange);
     }
 
     public GitConfigurationSource(


### PR DESCRIPTION
- **build: add package reference to Microsoft.Extensions.FileProviders.Composite**
  

- **build: add package reference to Microsoft.Extensions.FileProviders.Physical**
  

- **refactor: add flag 'reloadOnChange' to GitConfigurationProvider.ctor() taking repo/global/xdg/system configuration paths**
  

- **refactor: add flag 'reloadOnChange' to GitConfigurationSource.ctor() taking repo/global/xdg/system configuration paths**
  

- **refactor: add flag 'reloadOnChange' to IConfigurationBuilder.AddGitConfig() extension method taking repo/global/xdg/system configuration paths**
  

- **refactor: add flag 'reloadOnChange' to GitConfigurationProvider.ctor() taking a single repository path**
  

- **refactor: add flag 'reloadOnChange' to GitConfigurationSource.ctor() taking a single repository path**
  

- **refactor: add flag 'reloadOnChange' to IConfigurationBuilder.AddGitConfig() extension method taking a single repository path**
  

- **feat: implement GitConfigurationProvider.Reload()**
  

- **feat: implement support for reloading configuration on change in GitConfigurationProvider.ctor(configuration paths)**
  reason: this is the only case where the file paths to watch are entirely known
          as LibGitSharp does not expose the underlying libgit and its internals
  