### PR TITLE
refactor: unit tests modify the global configuration

### DIFF
--- a/Tests/ConfigurationTests/CliGit.cs
+++ b/Tests/ConfigurationTests/CliGit.cs
@@ -32,9 +32,9 @@ public static class CliGit
 
     public static int Init(string path) => RunCommand($"git -C {path} init");
 
-    public static int ConfigUserName(string path, string userName) => RunCommand($"git -C {path} config user.name {userName}");
+    public static int ConfigUserName(string path, string userName) => RunCommand($"git -C {path} config --global user.name {userName}");
 
-    public static int ConfigUserEmail(string path, string userEmail) => RunCommand($"git -C {path} config user.email {userEmail}");
+    public static int ConfigUserEmail(string path, string userEmail) => RunCommand($"git -C {path} config --global user.email {userEmail}");
 
     public static int ConfigLocalUserName(string path, string userName) => RunCommand($"git -C {path} config --local user.name {userName}");
 
@@ -42,37 +42,37 @@ public static class CliGit
         RunCommand($"git -C {path} config --local user.email {userEmail}");
 
     public static int AddAlias(string path, string alias, string command) =>
-        RunCommand($"git -C {path} config alias.{alias} \"{command}\"");
+        RunCommand($"git -C {path} config --global alias.{alias} \"{command}\"");
 
     public static int AddLocalAlias(string path, string alias, string command) =>
         RunCommand($"git -C {path} config --local alias.{alias} \"{command}\"");
 
     public static int ConfigRebase(string path, string key, bool value) =>
-        RunCommand($"git -C {path} config rebase.{key} {value.ToString().ToLowerInvariant()}");
+        RunCommand($"git -C {path} config --global rebase.{key} {value.ToString().ToLowerInvariant()}");
 
     public static int ConfigLocalRebase(string path, string key, bool value) =>
         RunCommand($"git -C {path} config --local rebase.{key} {value.ToString().ToLowerInvariant()}");
 
     public static int ConfigPull(string path, string key, bool value) =>
-        RunCommand($"git -C {path} config pull.{key} {value.ToString().ToLowerInvariant()}");
+        RunCommand($"git -C {path} config --global pull.{key} {value.ToString().ToLowerInvariant()}");
 
     public static int ConfigLocalPull(string path, string key, bool value) =>
         RunCommand($"git -C {path} config --local pull.{key} {value.ToString().ToLowerInvariant()}");
 
     public static int ToggleRerere(string path, bool value) =>
-        RunCommand($"git -C {path} config rerere.enabled {value.ToString().ToLowerInvariant()}");
+        RunCommand($"git -C {path} config --global rerere.enabled {value.ToString().ToLowerInvariant()}");
 
     public static int ToggleLocalRerere(string path, bool value) =>
         RunCommand($"git -C {path} config --local rerere.enabled {value.ToString().ToLowerInvariant()}");
 
     public static int AddGearsToken(string path, string url, string token) =>
-        RunCommand($"git -C {path} config gears.\"{url}\".token {token}");
+        RunCommand($"git -C {path} config --global gears.\"{url}\".token {token}");
 
     public static int AddLocalGearsToken(string path, string url, string token) =>
         RunCommand($"git -C {path} config --local gears.\"{url}\".token {token}");
 
     public static int SetLogging(string path, string key, string value) =>
-        RunCommand($"git -C {path} config Logging.LogLevel.\"{key}\" {value}");
+        RunCommand($"git -C {path} config --global Logging.LogLevel.\"{key}\" {value}");
 
     public static int SetLocalLogging(string path, string key, string value) =>
         RunCommand($"git -C {path} config --local Logging.LogLevel.\"{key}\" {value}");

--- a/Tests/ConfigurationTests/ConfigurationExtensions.cs
+++ b/Tests/ConfigurationTests/ConfigurationExtensions.cs
@@ -5,9 +5,11 @@ namespace ConfigurationTests;
 
 public static class ConfigurationExtensions
 {
-    public static void ConfigUserName(this Configuration config, string userName) => config.Set("user.name", userName);
+    public static void ConfigUserName(this Configuration config, string userName) =>
+        config.Set("user.name", userName, level: ConfigurationLevel.Global);
 
-    public static void ConfigUserEmail(this Configuration config, string userEmail) => config.Set("user.email", userEmail);
+    public static void ConfigUserEmail(this Configuration config, string userEmail) =>
+        config.Set("user.email", userEmail, level: ConfigurationLevel.Global);
 
     public static void ConfigLocalUserName(this Configuration config, string userName) =>
         config.Set("user.name", userName, level: ConfigurationLevel.Local);
@@ -15,32 +17,38 @@ public static class ConfigurationExtensions
     public static void ConfigLocalUserEmail(this Configuration config, string userEmail) =>
         config.Set("user.email", userEmail, level: ConfigurationLevel.Local);
 
-    public static void AddAlias(this Configuration config, string alias, string command) => config.Set($"alias.{alias}", command);
+    public static void AddAlias(this Configuration config, string alias, string command) =>
+        config.Set($"alias.{alias}", command, level: ConfigurationLevel.Global);
 
     public static void AddLocalAlias(this Configuration config, string alias, string command) =>
         config.Set($"alias.{alias}", command, level: ConfigurationLevel.Local);
 
-    public static void ConfigRebase(this Configuration config, string key, bool value) => config.Set($"rebase.{key}", value);
+    public static void ConfigRebase(this Configuration config, string key, bool value) =>
+        config.Set($"rebase.{key}", value, level: ConfigurationLevel.Global);
 
     public static void ConfigLocalRebase(this Configuration config, string key, bool value) =>
         config.Set($"rebase.{key}", value, level: ConfigurationLevel.Local);
 
-    public static void ConfigPull(this Configuration config, string key, bool value) => config.Set($"pull.{key}", value);
+    public static void ConfigPull(this Configuration config, string key, bool value) =>
+        config.Set($"pull.{key}", value, level: ConfigurationLevel.Global);
 
     public static void ConfigLocalPull(this Configuration config, string key, bool value) =>
         config.Set($"pull.{key}", value, level: ConfigurationLevel.Local);
 
-    public static void ToggleRerere(this Configuration config, bool value) => config.Set("rerere.enabled", value);
+    public static void ToggleRerere(this Configuration config, bool value) =>
+        config.Set("rerere.enabled", value, level: ConfigurationLevel.Global);
 
     public static void ToggleLocalRerere(this Configuration config, bool value) =>
         config.Set("rerere.enabled", value, level: ConfigurationLevel.Local);
 
-    public static void AddGearsToken(this Configuration config, string url, string token) => config.Set($"gears.{url}.token", token);
+    public static void AddGearsToken(this Configuration config, string url, string token) =>
+        config.Set($"gears.{url}.token", token, level: ConfigurationLevel.Global);
 
     public static void AddLocalGearsToken(this Configuration config, string url, string token) =>
         config.Set($"gears.{url}.token", token, level: ConfigurationLevel.Local);
 
-    public static void SetLogging(this Configuration config, string key, string value) => config.Set($"Logging.LogLevel.{key}", value);
+    public static void SetLogging(this Configuration config, string key, string value) =>
+        config.Set($"Logging.LogLevel.{key}", value, level: ConfigurationLevel.Global);
 
     public static void SetLocalLogging(this Configuration config, string key, string value) =>
         config.Set($"Logging.LogLevel.{key}", value, level: ConfigurationLevel.Local);

--- a/Tests/ConfigurationTests/ConfigurationTests.cs
+++ b/Tests/ConfigurationTests/ConfigurationTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace ConfigurationTests;
 
+[Collection("Sequential")]
 public class GlobalUserConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -46,6 +47,7 @@ public class GlobalUserConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalUserConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -92,6 +94,7 @@ public class LocalUserConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalAliasConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -131,6 +134,7 @@ public class GlobalAliasConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalAliasConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -170,6 +174,7 @@ public class LocalAliasConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalRebaseConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -214,6 +219,7 @@ public class GlobalRebaseConfigurationTest : IClassFixture<TestRepositoryFixture
     }
 }
 
+[Collection("Sequential")]
 public class LocalRebaseConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -258,6 +264,7 @@ public class LocalRebaseConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalPullConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -302,6 +309,7 @@ public class GlobalPullConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalPullConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -346,6 +354,7 @@ public class LocalPullConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalRerereConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -385,6 +394,7 @@ public class GlobalRerereConfigurationTest : IClassFixture<TestRepositoryFixture
     }
 }
 
+[Collection("Sequential")]
 public class LocalRerereConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -424,6 +434,7 @@ public class LocalRerereConfigurationTest : IClassFixture<TestRepositoryFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalGearTokenConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -468,6 +479,7 @@ public class GlobalGearTokenConfigurationTest : IClassFixture<TestRepositoryFixt
     }
 }
 
+[Collection("Sequential")]
 public class LocalGearTokenConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -512,6 +524,7 @@ public class LocalGearTokenConfigurationTest : IClassFixture<TestRepositoryFixtu
     }
 }
 
+[Collection("Sequential")]
 public class GlobalLoggingLevelConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;
@@ -551,6 +564,7 @@ public class GlobalLoggingLevelConfigurationTest : IClassFixture<TestRepositoryF
     }
 }
 
+[Collection("Sequential")]
 public class LocalLoggingLevelConfigurationTest : IClassFixture<TestRepositoryFixture>
 {
     private readonly TestRepositoryFixture fixture;

--- a/Tests/ConfigurationTests/GitCliConfigurationTests.cs
+++ b/Tests/ConfigurationTests/GitCliConfigurationTests.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Configuration;
 
 namespace ConfigurationTests;
 
+[Collection("Sequential")]
 public class CliGitGlobalUserConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -43,6 +44,7 @@ public class CliGitGlobalUserConfigurationTest : IClassFixture<CliGitTestReposit
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalUserConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -86,6 +88,7 @@ public class CliGitLocalUserConfigurationTest : IClassFixture<CliGitTestReposito
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalAliasConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -122,6 +125,7 @@ public class CliGitGlobalAliasConfigurationTest : IClassFixture<CliGitTestReposi
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalAliasConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -158,6 +162,7 @@ public class CliGitLocalAliasConfigurationTest : IClassFixture<CliGitTestReposit
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalRebaseConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -199,6 +204,7 @@ public class CliGitGlobalRebaseConfigurationTest : IClassFixture<CliGitTestRepos
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalRebaseConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -240,6 +246,7 @@ public class CliGitLocalRebaseConfigurationTest : IClassFixture<CliGitTestReposi
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalPullConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -281,6 +288,7 @@ public class CliGitGlobalPullConfigurationTest : IClassFixture<CliGitTestReposit
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalPullConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -322,6 +330,7 @@ public class CliGitLocalPullConfigurationTest : IClassFixture<CliGitTestReposito
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalRerereConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -358,6 +367,7 @@ public class CliGitGlobalRerereConfigurationTest : IClassFixture<CliGitTestRepos
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalRerereConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -394,6 +404,7 @@ public class CliGitLocalRerereConfigurationTest : IClassFixture<CliGitTestReposi
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalGearTokenConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -430,6 +441,7 @@ public class CliGitGlobalGearTokenConfigurationTest : IClassFixture<CliGitTestRe
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalGearTokenConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -466,6 +478,7 @@ public class CliGitLocalGearTokenConfigurationTest : IClassFixture<CliGitTestRep
     }
 }
 
+[Collection("Sequential")]
 public class CliGitGlobalLoggingLevelConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;
@@ -502,6 +515,7 @@ public class CliGitGlobalLoggingLevelConfigurationTest : IClassFixture<CliGitTes
     }
 }
 
+[Collection("Sequential")]
 public class CliGitLocalLoggingLevelConfigurationTest : IClassFixture<CliGitTestRepositoryFixture>
 {
     private readonly CliGitTestRepositoryFixture fixture;

--- a/Tests/ConfigurationTests/TestRepositoryFixture.cs
+++ b/Tests/ConfigurationTests/TestRepositoryFixture.cs
@@ -64,6 +64,7 @@ public class TestRepositoryFixture : TempRepositoryFixture
             factory: (path) =>
             {
                 Repository.Init(path: path);
+                CliGit.ConfigUserName(path: path, "globalGitUser");
                 return new Repository(path);
             }
         ) { }

--- a/Tests/HostingTests/GlobalConfigurationTests.cs
+++ b/Tests/HostingTests/GlobalConfigurationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace HostingTests;
 
+[Collection("Sequential")]
 public class GlobalUserConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -50,6 +51,7 @@ public class GlobalUserConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalAliasConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -90,6 +92,7 @@ public class GlobalAliasConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalRebaseConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -135,6 +138,7 @@ public class GlobalRebaseConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalPullConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -180,6 +184,7 @@ public class GlobalPullConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalRerereConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -220,6 +225,7 @@ public class GlobalRerereConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalGearTokenConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -265,6 +271,7 @@ public class GlobalGearTokenConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class GlobalLoggingLevelConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;

--- a/Tests/HostingTests/GlobalConfigurationTests.cs
+++ b/Tests/HostingTests/GlobalConfigurationTests.cs
@@ -1,4 +1,5 @@
 using KageKirin.Extensions.Configuration.GitConfig;
+using LibGit2Sharp;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -19,8 +20,8 @@ public class GlobalUserConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.ConfigUserName(userName: userName);
-        fixture.ConfigUserEmail(userEmail: userEmail);
+        fixture.ConfigUserName(userName: userName, level: ConfigurationLevel.Global);
+        fixture.ConfigUserEmail(userEmail: userEmail, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -62,7 +63,7 @@ public class GlobalAliasConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.AddAlias(alias: aliasName, command: aliasCommand);
+        fixture.AddAlias(alias: aliasName, command: aliasCommand, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -104,8 +105,8 @@ public class GlobalRebaseConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.ConfigRebase(key: autostashKey, value: autostashValue);
-        fixture.ConfigRebase(key: autosquashKey, value: autosquashValue);
+        fixture.ConfigRebase(key: autostashKey, value: autostashValue, level: ConfigurationLevel.Global);
+        fixture.ConfigRebase(key: autosquashKey, value: autosquashValue, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -149,8 +150,8 @@ public class GlobalPullConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.ConfigPull(key: rebaseKey, value: rebaseValue);
-        fixture.ConfigPull(key: autostashKey, value: autostashValue);
+        fixture.ConfigPull(key: rebaseKey, value: rebaseValue, level: ConfigurationLevel.Global);
+        fixture.ConfigPull(key: autostashKey, value: autostashValue, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -192,7 +193,7 @@ public class GlobalRerereConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.ToggleRerere(value: toggleValue);
+        fixture.ToggleRerere(value: toggleValue, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -232,7 +233,7 @@ public class GlobalGearTokenConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.AddGearsToken(url: gearUrl, token: gearToken);
+        fixture.AddGearsToken(url: gearUrl, token: gearToken, level: ConfigurationLevel.Global);
     }
 
     [Fact]
@@ -277,7 +278,7 @@ public class GlobalLoggingLevelConfigurationTest : IClassFixture<HostingFixture>
         Assert.NotNull(fixture.Repository);
         Assert.NotNull(fixture.Repository.Config);
 
-        fixture.SetLogging(key: loggingSection, value: loggingLevel);
+        fixture.SetLogging(key: loggingSection, value: loggingLevel, level: ConfigurationLevel.Global);
     }
 
     [Fact]

--- a/Tests/HostingTests/LocalConfigurationTests.cs
+++ b/Tests/HostingTests/LocalConfigurationTests.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.Logging;
 
 namespace HostingTests;
 
+[Collection("Sequential")]
 public class LocalUserConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -50,6 +51,7 @@ public class LocalUserConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalAliasConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -90,6 +92,7 @@ public class LocalAliasConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalRebaseConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -135,6 +138,7 @@ public class LocalRebaseConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalPullConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -180,6 +184,7 @@ public class LocalPullConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalRerereConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -220,6 +225,7 @@ public class LocalRerereConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalGearTokenConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;
@@ -265,6 +271,7 @@ public class LocalGearTokenConfigurationTest : IClassFixture<HostingFixture>
     }
 }
 
+[Collection("Sequential")]
 public class LocalLoggingLevelConfigurationTest : IClassFixture<HostingFixture>
 {
     private readonly HostingFixture fixture;


### PR DESCRIPTION
- **refactor(ut): change git CLI wrapper methods to actually set global settings**
  caveat: this is potentially desctructive when run locally.
  

- **refactor(ut): change LibGit2Sharp.Configuration extension methods to actually set global settings**
  caveat: this is potentially desctructive when run locally.
  

- **refactor(ut): change Hosting unit tests acting on the global configuration to actually set global settings**
  caveat: this is potentially destructive when run locally.


- **fix(ut): set dummy global user after initialzing repo in TestRepositoryFixture**


- **fix(ut): set configuration unit tests to run sequentially**


- **fix(ut): set hosting unit tests to run sequentially**
